### PR TITLE
Added description for Xpazeman mods

### DIFF
--- a/descriptions/xpazeman-mod-installer-description.json
+++ b/descriptions/xpazeman-mod-installer-description.json
@@ -1,0 +1,9 @@
+{
+	"name": "Xpazeman Collection",
+	"description": "Mods from xpazeman",
+	"url": "https://github.com/Xpazeman",
+	"releases": [],
+	"definitions": [
+		"https://github.com/Xpazeman/Mod-Installer-Description"
+	]
+}


### PR DESCRIPTION
In order to have my mods load on the ModInstaller, but not have to bother you with each update and release, I have added a description file that redirects to https://github.com/Xpazeman/Mod-Installer-Description/blob/master/mod-installer-description.json

Tested adding as source both the redirecting definition file, as well as the target one, both working.