### PR TITLE
Fixed focus request for close button on ProgressDialog

### DIFF
--- a/src/main/java/me/wulfmarius/modinstaller/ui/ProgressDialogController.java
+++ b/src/main/java/me/wulfmarius/modinstaller/ui/ProgressDialogController.java
@@ -61,6 +61,7 @@ public class ProgressDialogController implements ProgressListener {
 
         this.progressBarStep.setProgress(1);
         this.buttonClose.setDisable(false);
+        this.buttonClose.requestFocus();
         this.clock.stop();
 
         if (this.autoCloseWithoutErrors && !this.hadError) {
@@ -154,8 +155,6 @@ public class ProgressDialogController implements ProgressListener {
     private void initialize() {
         this.modInstaller.addProgressListener(this);
         this.labelTime.textProperty().bind(this.clock.formattedTime);
-
-        this.buttonClose.requestFocus();
     }
 
     @FXML


### PR DESCRIPTION
Focus request for close button on ProgressDialog now made when processing ProgressListener "finished" event, after the close button it has been enabled; previous focus request did not work as button was disabled at time of request.